### PR TITLE
Toki Pona update

### DIFF
--- a/YIT.tex
+++ b/YIT.tex
@@ -84,11 +84,10 @@ Let $\mathcal C$ be a small category, and $F$ a functor from this category to th
 	\]
 	(tämä funktio on bijektiivinen).
 }
-\tran{Toki pona (ISO 639-2 art)}{oko lili pi Jonewa}{$\mathcal K$ li lili kulupu en $P$ li suli tawa pana $\mathcal K$ en noka kulupu pi mute. $A$ li ijo pi $\mathcal K$. Suli suli tawa $\hom(-,A)\to P$ en ijo $PA$ li sama; ona sama tan
+\tran{Toki pona (ISO 639-2 art)}{oko lili Joneta}{$\mathcal K$ li kulupu lili. $P$ li tawa kulupu tan kulupu  $\mathcal K$, tawa kulupu pi mute ijo. $A$ li ijo lon kulupu $\mathcal K$, la tawa suli suli $\hom(-,A)\to P$ li sama ijo $PA$ kepeken tawa ni:
 \[
-	\Big(\xi : \hom(-,A)\Rightarrow P\Big) \mapsto \xi_A(1_A)
-\]
-li pona tawa sama.}
+	\Big(\xi : \mathrm{tawa}(-,A)\Rightarrow P\Big) \mapsto \xi_A(1_A).
+\]}
 \tran{{\tp toki-pona} (ISO 639-2 art)}{{\tp li lili oko pi Jonewa}}{$\mathcal K$ {\tp li lili kulupu en} $P$ {\tp li suli tawa pana} $\mathcal K$ {\tp en noka kulupu pi mute}. $A$ {\tp li ijo pi} $\mathcal K$. {\tp suli suli tawa} $\hom(-,A)\to P$ {\tp en ijo} $PA$ {\tp li sama; ona sama tan}
 \[
 	\Big(\xi : \hom(-,A)\Rightarrow P\Big) \mapsto \xi_A(1_A)

--- a/YIT.tex
+++ b/YIT.tex
@@ -84,7 +84,7 @@ Let $\mathcal C$ be a small category, and $F$ a functor from this category to th
 	\]
 	(tämä funktio on bijektiivinen).
 }
-\tran{Toki pona (ISO 639-2 art)}{oko lili Joneta}{$\mathcal K$ li kulupu lili. $P$ li tawa kulupu tan kulupu  $\mathcal K$, tawa kulupu pi mute ijo. $A$ li ijo lon kulupu $\mathcal K$, la tawa suli suli $\hom(-,A)\to P$ li sama ijo $PA$ kepeken tawa ni:
+\tran{toki pona (ISO 639-2 art)}{oko lili Joneta}{$\mathcal K$ li kulupu lili. $P$ li tawa kulupu tan kulupu  $\mathcal K$, tawa kulupu pi mute ijo. $A$ li ijo lon kulupu $\mathcal K$, la tawa suli suli $\hom(-,A)\to P$ li sama ijo $PA$ kepeken tawa ni:
 \[
 	\Big(\xi : \mathrm{tawa}(-,A)\Rightarrow P\Big) \mapsto \xi_A(1_A).
 \]}


### PR DESCRIPTION
I wasn't able to get the document to compile proper, so I edited the text of the latin Toki Pona entry only (one note - Yoneta\Yonewa should be spelled in a cartouche if at all possible as recommend in the Toki Pona book here - http://tokipona.net/tp/janpije/hieroglyphs.php ).  You might want to edit the sitelen pona to be the same.

You use "adjective noun" order I think ("lili kulupu", "suli tawa", etc.) but Toki Pona is noun adjective, so I changed things around.  
I used Yoneta as the latinisation rather than Yonewa because it more closely follows the examples in the official book, as well as a phonetic conversion guideline given by jan Sonja here - http://tokipona.net/tp/janpije/tpize.php ).

I changed hom to tawa (because why not).

I treat variable names as proper names, and they require qualification "A li ijo pi K" doesn't work, but "A li ijo pi kulupu K" does.

A prepositions changed, 'pi's replaced with 'lon' where it seemed nice.

I collapsed "a pi b" statements to "a b".  In the official dialect of Toki Pona, there are very few theoretical grounds to differentiate the two. 

It's not watertight, but I think it's better...

(I'm esp. happy with 'kulupu pi mute ijo' for 'categorified of objectified multiplicities' for 'Set' :P)